### PR TITLE
fix: cast VAE to model dtype after loading and bash for start #4

### DIFF
--- a/backend/models/flux_wrapper.py
+++ b/backend/models/flux_wrapper.py
@@ -200,6 +200,7 @@ class FluxInpainter:
                 logger.info(f"Loading Native AutoEncoder from {ae_path_file}...")
                 os.environ["AE_MODEL_PATH"] = ae_path_file
                 self.ae = load_ae(model_name, device=self.device)
+                self.ae = self.ae.to(self.dtype)
                 self.ae.eval()
                 # MPS Hack for native? Usually fine if logic in decode handles it.
                 loaded_native = True
@@ -211,6 +212,7 @@ class FluxInpainter:
             else:
                 logger.warning("No local VAE found, trying HuggingFace download...")
                 self.ae = load_ae(model_name, device=self.device)
+                self.ae = self.ae.to(self.dtype)
                 self.ae.eval()
             
             self.using_native_ae = loaded_native

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,27 @@
+#!/bin/bash
+# change to 
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+export AE_MODEL_PATH="$SCRIPT_DIR/backend/models/flux2/vae/ae.safetensors"
+
+# Fonction de nettoyage
+cleanup() {
+    echo "Arrêt des services..."
+    kill $BACKEND_PID 2>/dev/null
+    wait $BACKEND_PID 2>/dev/null
+    echo "Services arrêtés."
+    exit 0
+}
+
+# Intercepter Ctrl+C et kill
+trap cleanup SIGINT SIGTERM
+
+./run_backend.sh &
+BACKEND_PID=$!
+
+./run_frontend.sh &
+FRONTEND_PID=$!
+
+echo "Backend PID: $BACKEND_PID | Frontend PID: $FRONTEND_PID"
+
+# Attendre que les deux tournent (garde le script actif)
+wait


### PR DESCRIPTION
When loading the native AutoEncoder via load_ae(), the VAE weights remain in float32 while the rest of the pipeline (flow model, input tensors) runs in bfloat16. 
```
This causes a RuntimeError at inference time during ae.encode():
```
RuntimeError: Input type (c10::BFloat16) and bias type (float) should be the same
The FluxAEWrapper fallback already handles this correctly by accepting a dtype parameter, but the two code paths using load_ae() in load_model() don't cast the VAE to the model's dtype.

Fix: Added self.ae.to(self.dtype) after each load_ae() call in flux_wrapper.py to align the VAE dtype with the rest of the pipeline.

Ans create a script for launch the application and export the VAE Folder for the "story element" 