### PR TITLE
fix: unpack tuple return value of enhance_prompt() in image and video tasks

### DIFF
--- a/backend/tasks/image.py
+++ b/backend/tasks/image.py
@@ -61,7 +61,7 @@ async def generate_image_task(job_id: str, params: dict):
                     )
                 else:
                     logger.info(f"Enhancing image prompt via {provider}...")
-                    enhanced = llm_enhance(prompt=prompt, is_video=False, seed=seed)
+                    enhanced, _ = llm_enhance(prompt=prompt, is_video=False, seed=seed)
                     if enhanced and enhanced != prompt:
                         logger.info(f"Enhanced image prompt: {enhanced[:100]}...")
                         update_job_db(job_id, "processing", enhanced_prompt=enhanced)

--- a/backend/tasks/video.py
+++ b/backend/tasks/video.py
@@ -209,7 +209,7 @@ async def generate_standard_video_task(job_id: str, params: dict, pipeline):
                         )
                     else:
                         logger.info(f"Enhancing single-frame prompt via {provider}...")
-                        enhanced = llm_enhance(prompt=prompt, is_video=False, seed=seed)
+                        enhanced, _ = llm_enhance(prompt=prompt, is_video=False, seed=seed)
                         if enhanced and enhanced != prompt:
                             prompt = enhanced
                             update_job_db(job_id, "processing", enhanced_prompt=prompt)


### PR DESCRIPTION
## Problem

`enhance_prompt()` returns a `(str, bool)` tuple, but two call sites were not unpacking it:

- `tasks/image.py` (image generation via Flux2)
- `tasks/video.py` (single-frame / Flux2 path in standard video task)

This caused the full tuple to be assigned to `prompt` and passed as-is to the Flux2 text encoder. The Qwen3 tokenizer then received the string representation `"('a beautiful sunset', False)"` instead of the actual prompt, making text conditioning effectively non-functional: the generated image looked identical regardless of what the user typed.

## Root cause

The bug only manifests when using the **Ollama** provider (or any non-`gemma` provider), because with `gemma` the `if provider == "gemma":` branch is taken and the `else` block with the unpacking bug is never reached.

The other callers already handle the return value correctly:
- `tasks/chained.py` line 204: `enhanced, _ = llm_enhance(...)`
- `storyboard/manager.py` line 110: `enhanced, _ = llm_enhance(...)`
- Other paths in `tasks/video.py` (lines 377, 453, 496): already correct

## Fix

Unpack the return tuple properly with `enhanced, _ = llm_enhance(...)` in both affected files (2-char change each).

## Test plan

- [ ] With Ollama provider enabled, generate an image — confirm output varies with different prompts
- [ ] With Ollama provider enabled, generate a single-frame video — same check
- [ ] With Gemma provider (default), verify no regression
