### PR TITLE
fix: wrap encode_video generator consumption in torch.no_grad()

### DIFF
--- a/LTX-2/packages/ltx-pipelines/src/ltx_pipelines/utils/media_io.py
+++ b/LTX-2/packages/ltx-pipelines/src/ltx_pipelines/utils/media_io.py
@@ -190,7 +190,14 @@ def encode_video(
     if isinstance(video, torch.Tensor):
         video = iter([video])
 
-    first_chunk = next(video)
+    # Wrap all generator consumption in no_grad: the video generator may have been
+    # created inside torch.inference_mode() (via @smart_inference_mode on the pipeline),
+    # making the latent tensors inference tensors. When next() is called here — outside
+    # that context — the VAE forward pass runs with autograd active, which cannot save
+    # inference tensors for backward. torch.no_grad() prevents autograd tracking and
+    # avoids the "Inference tensors cannot be saved for backward" error on CUDA.
+    with torch.no_grad():
+        first_chunk = next(video)
 
     _, height, width, _ = first_chunk.shape
 
@@ -199,10 +206,10 @@ def encode_video(
     stream.width = width
     stream.height = height
     stream.pix_fmt = "yuv420p"
-    
+
     # Optimization for single-frame (Image Generation) or static video
-    # Although encode_single_frame handles pure images, sometimes the pipeline 
-    # runs a 1-frame "video" job. 
+    # Although encode_single_frame handles pure images, sometimes the pipeline
+    # runs a 1-frame "video" job.
     if video_chunks_number == 1 and fps <= 1:
         stream.options = {"crf": "18", "preset": "veryslow"} # High quality for single image
     else:
@@ -220,12 +227,13 @@ def encode_video(
         yield first_chunk
         yield from tiles_generator
 
-    for video_chunk in tqdm(all_tiles(first_chunk, video), total=video_chunks_number):
-        video_chunk_cpu = video_chunk.to("cpu").numpy()
-        for frame_array in video_chunk_cpu:
-            frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
-            for packet in stream.encode(frame):
-                container.mux(packet)
+    with torch.no_grad():
+        for video_chunk in tqdm(all_tiles(first_chunk, video), total=video_chunks_number):
+            video_chunk_cpu = video_chunk.detach().to("cpu").numpy()
+            for frame_array in video_chunk_cpu:
+                frame = av.VideoFrame.from_ndarray(frame_array, format="rgb24")
+                for packet in stream.encode(frame):
+                    container.mux(packet)
 
     # Flush encoder
     for packet in stream.encode():


### PR DESCRIPTION
## Problem

On CUDA devices, video generation crashes after the entire diffusion loop completes (potentially hours of computation) with:

```
RuntimeError: Inference tensors cannot be saved for backward. Please do not use
Tensors created in inference mode in computation tracked by autograd.
```

## Root Cause

The flow is:
1. `TI2VidTwoStagesPipeline.__call__` is decorated with `@smart_inference_mode()`, which uses `torch.inference_mode()` on CUDA — marking all tensors created within it as **inference tensors**.
2. Inside `__call__`, `decode_video()` returns a **Python generator**. Generators are lazy — the body doesn't execute when the generator is created, only when `next()` is called.
3. `__call__` returns the unevaluated generator to `encode_video()`, which runs **outside** the inference_mode context.
4. When `encode_video()` calls `next(video)`, the generator body executes `video_decoder(latent)` — the VAE forward pass — with an inference tensor as input and autograd active.
5. PyTorch tries to save the inference tensor for the backward pass → crash.

**Mac/MPS users are unaffected** because `smart_inference_mode()` returns `torch.no_grad()` on MPS, which does not create inference tensors.

## Fix

Wrap the generator consumption in `torch.no_grad()` inside `encode_video()`, as explicitly recommended by the PyTorch error message. This prevents autograd tracking during the VAE forward pass regardless of the inference tensor status of the latent input.

Also adds `.detach()` as a defensive measure before moving video chunks to CPU.

## Testing

Verified on Windows / CUDA (RTX 3080 10GB) — video generation now completes successfully end-to-end.
